### PR TITLE
Develop

### DIFF
--- a/script/vm.sh
+++ b/script/vm.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 branch="${GIT_BRANCH:-master}"
-sudo apt-get update -y &&
+curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+sudo apt-get --allow-releaseinfo-change update -y &&
 sudo apt-get install -y rubygems build-essential &&
 sudo apt-get install -y ruby-dev &&
 sudo gem install fluentd --no-doc &&


### PR DESCRIPTION
added command for apt public key and added --allow-releaseinfo-change flag for apt-get update command.

@ahsan13jan ,
The additional flag --allow-releaseinfo-change "Allows the update command to continue downloading data from a repository which changed its information of the release contained in the repository indicating e.g a new major release. APT will fail at the update command for such repositories until the change is confirmed to ensure the user is prepared for the change."

What happens here, is that the local apt database remembered your package-sources "release-information" to be "busterAsTesting", and when updating now "busterAsStable" is returned.
This results in the error, and the indication, that you need to "allow the change of the release version information".