### PR TITLE
Bugfix/dev 106714 rt 173 configure gcp log forwarder is failing

### DIFF
--- a/script/gcp.sh
+++ b/script/gcp.sh
@@ -13,7 +13,7 @@ function deploy_lm-logs {
 	
 	echo "Creating VM"
 	gcloud compute instances create ${NAME} \
-  --image debian-10-buster-v20201014 \
+  --image debian-11-bullseye-v20220621 \
   --image-project debian-cloud \
 	--machine-type=e2-micro
 


### PR DESCRIPTION
We were facing some issues with gcp logs integration https://github.com/logicmonitor/lm-logs-gcp....while running the vm.sh we are getting

ERROR:  Error installing fluent-plugin-gcloud-pubsub-custom:
        The last version of googleauth (~> 1.0) to support your Ruby & RubyGems was 1.1.3. Try installing it with `gem install googleauth -v 1.1.3` and then running the current command again
        googleauth requires Ruby version >= 2.6. The current ruby version is 2.5.0.
        
the ruby version supported by buster is only 2.5 and the buster version gives warning
WARNING: Some requests generated warnings:
 - The resource 'projects/debian-cloud/global/images/debian-10-buster-v20201014' is deprecated. A suggested replacement is 'projects/debian-cloud/global/images/debian-10-buster-v20201112'.
 
Updating our image from buster to bullseye....it has the ruby version support of 2.7