### PR TITLE
Bugfix/gcp logs error installing fluent plugin gcloud pubsub custom

### DIFF
--- a/script/vm.sh
+++ b/script/vm.sh
@@ -6,6 +6,8 @@ sudo apt-get --allow-releaseinfo-change update -y &&
 sudo curl -fsSL https://toolbelt.treasuredata.com/sh/install-debian-bullseye-td-agent4.sh | sh
 sudo td-agent-gem install fluent-plugin-lm-logs &&
 sudo td-agent-gem install fluent-plugin-lm-logs-gcp &&
+sudo td-agent-gem install google-protobuf -v 3.25.0 &&
+sudo td-agent-gem install gapic-common -v 0.21.1 &&
 sudo td-agent-gem install fluent-plugin-gcloud-pubsub-custom &&
 curl  https://raw.githubusercontent.com/logicmonitor/lm-logs-gcp/${branch}/script/fluentd.conf --output template.conf &&
 envsubst < template.conf  | sed '/access_id \"\"/d;/access_key \"\"/d;/bearer_token \"\"/d' > fluentd.conf &&


### PR DESCRIPTION
Fixing the issue where we are getting below error 
Error installing fluent-plugin-gcloud-pubsub-custom:
--
The last version of google-protobuf (>= 3.25, < 5.0) to support your Ruby & RubyGems was 4.26.1

This plugin is transitively installed and requires ruby version >=3. However, td-agent is installing ruby 2.7 resulting in incompatibility. Hence, we are explicitly installing an older version of these plugins which work with ruby 2.7 to avoid this error.