### PR TITLE
Dev 178498 gcp log forwarder deployment error

### DIFF
--- a/script/vm.sh
+++ b/script/vm.sh
@@ -10,4 +10,4 @@ sudo fluent-gem install fluent-plugin-gcloud-pubsub-custom &&
 curl  https://raw.githubusercontent.com/logicmonitor/lm-logs-gcp/${branch}/script/fluentd.conf --output template.conf &&
 envsubst < template.conf  | sed '/access_id \"\"/d;/access_key \"\"/d;/bearer_token \"\"/d' > fluentd.conf &&
 sudo cp fluentd.conf /etc/fluent/fluentd.conf &&
-sudo systemctl restart td-agent
+sudo systemctl restart fluentd

--- a/script/vm.sh
+++ b/script/vm.sh
@@ -3,13 +3,11 @@
 branch="${GIT_BRANCH:-master}"
 curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
 sudo apt-get --allow-releaseinfo-change update -y &&
-sudo curl -fsSL https://toolbelt.treasuredata.com/sh/install-debian-bullseye-td-agent4.sh | sh
-sudo td-agent-gem install fluent-plugin-lm-logs &&
-sudo td-agent-gem install fluent-plugin-lm-logs-gcp &&
-sudo td-agent-gem install google-protobuf -v 3.25.0 &&
-sudo td-agent-gem install gapic-common -v 0.21.1 &&
-sudo td-agent-gem install fluent-plugin-gcloud-pubsub-custom &&
+sudo curl -fsSL https://toolbelt.treasuredata.com/sh/install-debian-bullseye-fluent-package5.sh | sh
+sudo fluent-gem install fluent-plugin-lm-logs &&
+sudo fluent-gem install fluent-plugin-lm-logs-gcp &&
+sudo fluent-gem install fluent-plugin-gcloud-pubsub-custom &&
 curl  https://raw.githubusercontent.com/logicmonitor/lm-logs-gcp/${branch}/script/fluentd.conf --output template.conf &&
 envsubst < template.conf  | sed '/access_id \"\"/d;/access_key \"\"/d;/bearer_token \"\"/d' > fluentd.conf &&
-sudo cp fluentd.conf /etc/td-agent/td-agent.conf &&
+sudo cp fluentd.conf /etc/fluent/fluentd.conf &&
 sudo systemctl restart td-agent


### PR DESCRIPTION
There were many gem versions issue recently caused due to the older version of ruby being installed by the td-agent. Hence, upgrading the version to fluent-package. For details see https://github.com/fluent/fluent-package-builder